### PR TITLE
fix: re-measure segmented control indicator on resize

### DIFF
--- a/.changeset/sixty-socks-fix.md
+++ b/.changeset/sixty-socks-fix.md
@@ -1,0 +1,6 @@
+---
+"@scouterna/ui-react": patch
+"@scouterna/ui-webc": patch
+---
+
+Recalculate Segmented Control indicator size on resize.

--- a/packages/ui-webc/src/components/segmented-control/segmented-control.tsx
+++ b/packages/ui-webc/src/components/segmented-control/segmented-control.tsx
@@ -61,6 +61,8 @@ export class ScoutSegmentedControl implements ComponentInterface {
 
   @Element() el!: HTMLElement;
 
+  private resizeObserver?: ResizeObserver;
+
   render() {
     const sizeClass = this.size === "small" ? "small" : "";
     const noTransitionClass = this.enableAnimations ? "" : "no-transition";
@@ -77,9 +79,22 @@ export class ScoutSegmentedControl implements ComponentInterface {
     this.updateChildrenAttributes();
     this.calculateIndicatorSizes();
 
+    // Re-measure the indicator whenever the host (and therefore the slotted
+    // buttons) is resized — for example when the component is placed inside a
+    // flex parent that redistributes space after mount, or when the viewport
+    // changes. Without this, the indicator stays at its mount-time width.
+    this.resizeObserver = new ResizeObserver(() =>
+      this.calculateIndicatorSizes(),
+    );
+    this.resizeObserver.observe(this.el);
+
     requestAnimationFrame(() => {
       this.enableAnimations = true;
     });
+  }
+
+  disconnectedCallback() {
+    this.resizeObserver?.disconnect();
   }
 
   getIndicator() {

--- a/packages/ui-webc/src/components/segmented-control/segmented-control.tsx
+++ b/packages/ui-webc/src/components/segmented-control/segmented-control.tsx
@@ -93,6 +93,13 @@ export class ScoutSegmentedControl implements ComponentInterface {
     });
   }
 
+  connectedCallback() {
+    if (this.resizeObserver) {
+      this.resizeObserver.observe(this.el);
+      this.calculateIndicatorSizes();
+    }
+  }
+
   disconnectedCallback() {
     this.resizeObserver?.disconnect();
   }


### PR DESCRIPTION
## Summary

- The `scout-segmented-control` indicator was measured once in `componentDidLoad` and only recalculated on `value` change (via the existing `@Watch("value") calculateIndicatorSizes`).
- When the component is placed inside a flex parent that redistributes space after mount (e.g. a filter row alongside other controls), the host shrinks from its initial layout but the indicator stays at the mount-time width — the active-segment highlight is visually oversized until the user clicks, which forces a recalculation.
- Adds a `ResizeObserver` on the host element that re-runs `calculateIndicatorSizes()` on resize, mirroring the pattern already used by `scout-tabs` (`packages/ui-webc/src/components/tabs/tabs.tsx:63-93`).
- Disconnects the observer in `disconnectedCallback`.

Non-breaking: no API or visual change for components that were already laid out at a stable width — just removes the stale-indicator bug for flex contexts and viewport resizes.

## Test plan

- [ ] Place a `scout-segmented-control` next to other flex children whose preferred sizes sum to more than the parent width and verify the indicator matches the active segment from first paint (previously it overflowed until clicked).
- [ ] Resize the viewport while the control is mounted and verify the indicator stays aligned.
- [ ] Existing storybook stories (`interaction-segmented-control--basic-example`, `--small`) render unchanged.
- [ ] Click between segments and confirm the indicator still animates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)